### PR TITLE
Quick fix for gcc version

### DIFF
--- a/BoardManagerFiles/package_stm_index.json
+++ b/BoardManagerFiles/package_stm_index.json
@@ -1257,7 +1257,7 @@
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz-linux-arm.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
               "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
               "checksum": "SHA-256:e77b934cdd616e68593327b09e8a17234ac56d457af571550b096729c80b3216",
               "size": "128001146"

--- a/BoardManagerFiles/package_stm_index.json
+++ b/BoardManagerFiles/package_stm_index.json
@@ -1259,8 +1259,8 @@
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
               "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
-              "checksum": "SHA-256:e77b934cdd616e68593327b09e8a17234ac56d457af571550b096729c80b3216",
-              "size": "128001146"
+              "checksum": "SHA-256:bb4e1f6c72e32a1696edcfdec57d32ece64ac691a0363e4781db559addac7b79",
+              "size": "135866864"
             }
           ]
         },

--- a/BoardManagerFiles/package_stm_index.json
+++ b/BoardManagerFiles/package_stm_index.json
@@ -1222,36 +1222,36 @@
           [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-win32-x32.zip",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-win32-x32.zip",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.2.1-1.1-win32-x32.zip",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.1-win32-x32.zip",
               "checksum": "SHA-256:d13aaff4caae6e5f1b871d50accc1759c4f5750574dbd4d6f6e3017c33f39dc6",
               "size": "128697954"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-darwin-x64.tar.gz",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-darwin-x64.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.2.1-1.1-darwin-x64.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.1-darwin-x64.tar.gz",
               "checksum": "SHA-256:6ff68117083624273c56244cf4242989a65069b376a9727ec4a230be824340f3",
               "size": "132371371"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-x64.tar.gz",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-x64.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.2.1-1.1-linux-x64.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.1-linux-x64.tar.gz",
               "checksum": "SHA-256:bbde117b97f229dfe63721c0323c3da6839e83cf302c8f4ff25e0f36ecf7a428",
               "size": "135081450"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-x32.tar.gz",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-x32.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.2.1-1.1-linux-x32.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.1-linux-x32.tar.gz",
               "checksum": "SHA-256:e9f4b5f3ebe7e4391e2423e4106493d7cfcdee9eee4a1f0766f1c23662093a49",
               "size": "137429272"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz-linux-arm64.tar.gz",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm64.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v1.0/xpack-arm-none-eabi-gcc-9.2.1-1.2-linux-arm64.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.2-linux-arm64.tar.gz",
               "checksum": "SHA-256:c04ff455c31d85b5e46f2be6b808fe5d8a0b98c67a9f30a1b51ff008c435e3b4",
               "size": "135766158"
             },

--- a/BoardManagerFiles/package_stm_index.json
+++ b/BoardManagerFiles/package_stm_index.json
@@ -1250,14 +1250,14 @@
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v1.0/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm64.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm64.tar.gz",
               "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm64.tar.gz",
               "checksum": "SHA-256:c04ff455c31d85b5e46f2be6b808fe5d8a0b98c67a9f30a1b51ff008c435e3b4",
               "size": "135766158"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v1.0/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
               "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
               "checksum": "SHA-256:e77b934cdd616e68593327b09e8a17234ac56d457af571550b096729c80b3216",
               "size": "128001146"

--- a/BoardManagerFiles/package_stm_index.json
+++ b/BoardManagerFiles/package_stm_index.json
@@ -1222,43 +1222,43 @@
           [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.2.1-1.1-win32-x32.zip",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.1-win32-x32.zip",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-win32-x32.zip",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-win32-x32.zip",
               "checksum": "SHA-256:d13aaff4caae6e5f1b871d50accc1759c4f5750574dbd4d6f6e3017c33f39dc6",
               "size": "128697954"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.2.1-1.1-darwin-x64.tar.gz",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.1-darwin-x64.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-darwin-x64.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-darwin-x64.tar.gz",
               "checksum": "SHA-256:6ff68117083624273c56244cf4242989a65069b376a9727ec4a230be824340f3",
               "size": "132371371"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.2.1-1.1-linux-x64.tar.gz",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.1-linux-x64.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-x64.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-x64.tar.gz",
               "checksum": "SHA-256:bbde117b97f229dfe63721c0323c3da6839e83cf302c8f4ff25e0f36ecf7a428",
               "size": "135081450"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.2.1-1.1-linux-x32.tar.gz",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.1-linux-x32.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-x32.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-x32.tar.gz",
               "checksum": "SHA-256:e9f4b5f3ebe7e4391e2423e4106493d7cfcdee9eee4a1f0766f1c23662093a49",
               "size": "137429272"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v1.0/xpack-arm-none-eabi-gcc-9.2.1-1.2-linux-arm64.tar.gz",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.2-linux-arm64.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v1.0/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm64.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm64.tar.gz",
               "checksum": "SHA-256:c04ff455c31d85b5e46f2be6b808fe5d8a0b98c67a9f30a1b51ff008c435e3b4",
               "size": "135766158"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v1.0/xpack-arm-none-eabi-gcc-9.2.1-1.2-linux-arm.tar.gz",
-              "archiveFileName": "xpack-arm-none-eabi-gcc-9.2.1-1.2-linux-arm.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v1.0/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
+              "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
               "checksum": "SHA-256:e77b934cdd616e68593327b09e8a17234ac56d457af571550b096729c80b3216",
               "size": "128001146"
             }

--- a/BoardManagerFiles/package_stm_index.json
+++ b/BoardManagerFiles/package_stm_index.json
@@ -1250,14 +1250,14 @@
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm64.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz-linux-arm64.tar.gz",
               "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm64.tar.gz",
               "checksum": "SHA-256:c04ff455c31d85b5e46f2be6b808fe5d8a0b98c67a9f30a1b51ff008c435e3b4",
               "size": "135766158"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/xpack-dev-tools/pre-releases/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
+              "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz-linux-arm.tar.gz",
               "archiveFileName": "xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz",
               "checksum": "SHA-256:e77b934cdd616e68593327b09e8a17234ac56d457af571550b096729c80b3216",
               "size": "128001146"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # IMPORTANT!
 
-this fork is only created to quickly fix problem preventing installation on Ras Pi. No further development will be made.
+This fork is only created to quickly fix problem preventing installation on Ras Pi. No further development will be made here.
+
+
 
 # stm32duino-raspberrypi
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@ By itself, the [Arduino IDE](https://www.arduino.cc/en/Main/Software) does not s
 
 Start and exit the Arduino IDE. This creates the directory `~/.arduino15`  in your home directory, and the file `~/.arduino15/preferences.txt`.
 
-With the Arduino IDE **not** running, edit `.arduino15/preferences.txt`, and add the following line:
-```
-allow_insecure_packages=true
-```
-This allows the use of unsigned packages like this one. Also tick "Verbose output during upload".
-
 Start  the Arduino IDE. In *File --> Preferences --> Additional Board Manager URLs:* paste the following url:
 ```
 https://raw.githubusercontent.com/koendv/stm32duino-raspberrypi/master/BoardManagerFiles/package_stm_index.json
@@ -24,7 +18,7 @@ In the search field, type "STM32". Install the "STM32 Cores" board package. Inst
 
 In the Tools menu select the STM32 cores as compilation target. As an example, if using a STM32F103 Blue Pill choose *Tools->Board: -> Generic STM32F1 series* .
 
-The tools to upload firmware are installed in the tools directory, `~/.arduino15/packages/STM32/tools/STM32Tools/1.3.2/tools/linux`.
+The tools to upload firmware are installed in the tools directory, `~/.arduino15/packages/STM32/tools/STM32Tools/1.4.0/tools/linux`.
 
 Run the shell script `install.sh` in the tools directory to install udev rules and add the current user to the `dialout` group.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# IMPORTANT!
+
+this fork is only created to quickly fix problem preventing installation on Ras Pi. No further development will be made.
+
 # stm32duino-raspberrypi
 
 This is software for Raspberry Pi that allows you to develop Arduino sketches for STM32 arm boards (Blue Pill).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# IMPORTANT!
-
-This fork is only created to quickly fix problem preventing installation on Ras Pi. No further development will be made here.
-
-
-
 # stm32duino-raspberrypi
 
 This is software for Raspberry Pi that allows you to develop Arduino sketches for STM32 arm boards (Blue Pill).


### PR DESCRIPTION
Updated to xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-arm.tar.gz